### PR TITLE
Made input path relative to the module that imported it

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ function bindKeyEvent(shortcut, event) {
 function ShortcutLoader(input) {
 	this.shortcuts = {};
 
-	const shortcuts = require(path.resolve(process.cwd(), input));
+	const pathOfModuleThatLoadedThis = path.dirname(module.parent.filename)
+	const pathToInput = path.resolve(pathOfModuleThatLoadedThis, input)
+	const shortcuts = require(pathToInput);
+	
 	if (!shortcuts) {
 		throw new Error('Shortcut input has been missing');
 	}


### PR DESCRIPTION
When using this module with electron-packager, `process.cwd()` is set to the home directory of the user, which means that input will not resolve properly. 

This makes `input` resolve relative to the module that imported it, as expected when requiring modules in node.

For example if you have a project that looks like this

```
shortcuts/
 - index.js
 - definitions.js
```

Then loading this inside of `shortcuts/index.js`

```
var shortcuts = require('electron-shortcut-loader')('./definitions')
```

Will work as expected with apps packaged using electron-packager and apps started using the electron command line.
